### PR TITLE
Add mongoid_userstamp to track user edits

### DIFF
--- a/lib/trogdir/changeset.rb
+++ b/lib/trogdir/changeset.rb
@@ -1,5 +1,8 @@
 class Changeset
   include Mongoid::History::Tracker
+  include Mongoid::Userstamp
+
+  mongoid_userstamp user_model: 'Syncinator'
 
   embeds_many :change_syncs
 

--- a/lib/trogdir/syncinator.rb
+++ b/lib/trogdir/syncinator.rb
@@ -2,6 +2,7 @@ require 'api_auth'
 
 class Syncinator
   include Mongoid::Document
+  include Mongoid::Userstamp::User
 
   FIXNUM_MAX = (2**(0.size * 8 -2) -1)
 

--- a/lib/trogdir_models.rb
+++ b/lib/trogdir_models.rb
@@ -7,6 +7,7 @@ end
 
 # Models
 require 'mongoid'
+require 'mongoid_userstamp'
 autoload :Person, 'trogdir/person'
 autoload :ID, 'trogdir/id'
 autoload :Email, 'trogdir/email'
@@ -29,3 +30,4 @@ autoload :AbsoluteUriValidator, 'trogdir/validators/absolute_uri_validator'
 
 require 'mongoid-history'
 Mongoid::History.tracker_class_name = :changeset
+Mongoid::History.modifier_class_name = 'Syncinator'

--- a/trogdir_models.gemspec
+++ b/trogdir_models.gemspec
@@ -18,6 +18,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'email_validator', '~> 1.4'
   s.add_dependency 'mongoid', '~> 4.0'
   s.add_dependency 'mongoid-history', '~> 0.4'
+  s.add_dependency 'mongoid_userstamp', '~> 0.4'
   s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'faker', '~> 1.3'
   s.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
Assigns a created_by attribute to Changeset to track which syncinators used the API to make what changes.