### PR TITLE
Validate that IDs are unique.

### DIFF
--- a/lib/trogdir/id.rb
+++ b/lib/trogdir/id.rb
@@ -11,6 +11,7 @@ class ID
 
   validates :type, presence: true, inclusion: { in: ID::TYPES }
   validates :identifier, presence: true
+  validates :identifier, uniqueness: {scope: :type}
   validate do |id|
     if Person.where(:id.ne => id.person.try(:id), :ids.elem_match => {identifier: id.identifier, type: id.type}).count > 0
       id.errors.add :identifier, 'must be unique'

--- a/spec/lib/trogdir/id_spec.rb
+++ b/spec/lib/trogdir/id_spec.rb
@@ -13,6 +13,7 @@ describe ID do
   it { should validate_presence_of :type }
   it { should validate_inclusion_of(:type).to_allow ID::TYPES }
   it { should validate_presence_of :identifier }
+  it { should validate_uniqueness_of(:identifier).scoped_to(:type) }
 
   describe 'uniqueness validation' do
     before { create(:id, identifier: 'johnd0', type: :netid) }


### PR DESCRIPTION
We were already validating that IDs were unique globally but this would still allow a single person to have duplicate ID records. This fixes that.