### PR TITLE
Fix multiple records getting saved on Syncinator#finish!

### DIFF
--- a/lib/trogdir/syncinator.rb
+++ b/lib/trogdir/syncinator.rb
@@ -81,7 +81,11 @@ class Syncinator
     sync_log.succeeded_at = Time.now
     sync_log.action = action
     sync_log.message = message
-    sync_log.save!
+    # There seems to be a bug in mongoid 4.0.2 that saves two records if you call just
+    # sync_log.save!. Calling save on the ChangeSync seems to be the best work-around for now.
+    # Thanks to Michael for finding the least-stupid workaround.
+    # TODO: do a simple sync_log.save! when this issue gets fixed.
+    sync_log.change_sync.save!
 
     sync_log
   end

--- a/spec/lib/trogdir/syncinator_spec.rb
+++ b/spec/lib/trogdir/syncinator_spec.rb
@@ -148,6 +148,18 @@ describe Syncinator do
       expect(subject.message).to eql message
     end
 
+    context 'when there is more than one syncinators' do
+      let!(:syncinator) { create(:syncinator); create :syncinator }
+
+      before do
+        sync_log.change_sync.changeset.change_syncs << ChangeSync.new(syncinator: Syncinator.first)
+      end
+
+      it "doesn't create create any new sync_logs" do
+        expect(subject.change_sync.reload.sync_logs.length).to eql 1
+      end
+    end
+
     it 'returns a sync_log' do
       expect(subject).to be_a SyncLog
     end
@@ -166,6 +178,18 @@ describe Syncinator do
       expect(subject.succeeded_at).to be_a Time
       expect(subject.action).to eql action
       expect(subject.message).to eql message
+    end
+
+    context 'when there is more than one syncinators' do
+      let!(:syncinator) { create(:syncinator); create :syncinator }
+
+      before do
+        sync_log.change_sync.changeset.change_syncs << ChangeSync.new(syncinator: Syncinator.first)
+      end
+
+      it "doesn't create create any new sync_logs" do
+        expect(subject.change_sync.reload.sync_logs.length).to eql 1
+      end
     end
 
     it 'returns a sync_log' do


### PR DESCRIPTION
This is the same bug as in the last commit, just caused by a different method. See comments in the code.