### PR TITLE
When a type exists, record it

### DIFF
--- a/lib/trogdir/address.rb
+++ b/lib/trogdir/address.rb
@@ -17,5 +17,14 @@ class Address
   validates :type, presence: true, inclusion: { in: Address::TYPES }
   validates :street_1, presence: true
 
-  track_history track_create: true, track_destroy: true
+  track_history changes_method: :track_type, track_create: true, track_destroy: true
+
+  private
+  def track_type
+    if changes.include? 'type'
+      changes
+    else
+      changes.merge("type" => [type, type])
+    end
+  end
 end

--- a/lib/trogdir/email.rb
+++ b/lib/trogdir/email.rb
@@ -13,5 +13,14 @@ class Email
   validates :type, presence: true, inclusion: { in: Email::TYPES }
   validates :address, presence: true, email: true
 
-  track_history track_create: true, track_destroy: true
+  track_history changes_method: :track_type, track_create: true, track_destroy: true
+
+  private
+  def track_type
+    if changes.include? 'type'
+      changes
+    else
+      changes.merge("type" => [type, type])
+    end
+  end
 end

--- a/lib/trogdir/id.rb
+++ b/lib/trogdir/id.rb
@@ -18,9 +18,18 @@ class ID
     end
   end
 
-  track_history track_create: true, track_destroy: true
+  track_history changes_method: :track_type, track_create: true, track_destroy: true
 
   def to_s
     identifier
+  end
+
+  private
+  def track_type
+    if changes.include? 'type'
+      changes
+    else
+      changes.merge("type" => [type, type])
+    end
   end
 end

--- a/lib/trogdir/phone.rb
+++ b/lib/trogdir/phone.rb
@@ -13,5 +13,14 @@ class Phone
   validates :type, presence: true, inclusion: { in: Phone::TYPES }
   validates :number, presence: true
 
-  track_history track_create: true, track_destroy: true
+  track_history changes_method: :track_type, track_create: true, track_destroy: true
+
+  private
+  def track_type
+    if changes.include? 'type'
+      changes
+    else
+      changes.merge("type" => [type, type])
+    end
+  end
 end

--- a/lib/trogdir/photo.rb
+++ b/lib/trogdir/photo.rb
@@ -15,5 +15,14 @@ class Photo
   validates :url, :height, :width, presence: true
   validates :url, absolute_uri: true
 
-  track_history track_create: true, track_destroy: true
+  track_history changes_method: :track_type, track_create: true, track_destroy: true
+
+  private
+  def track_type
+    if changes.include? 'type'
+      changes
+    else
+      changes.merge("type" => [type, type])
+    end
+  end
 end


### PR DESCRIPTION
When a type exists, record it in the original/modified hash
so that syncinators can pick up on a change