### PR TITLE
Default affiliation and entitlement to []

### DIFF
--- a/lib/trogdir/person.rb
+++ b/lib/trogdir/person.rb
@@ -33,8 +33,8 @@ class Person
   field :mailbox, type: String
 
   # Groups and permissions
-  field :entitlements, type: Array
-  field :affiliations, type: Array
+  field :entitlements, type: Array, default: []
+  field :affiliations, type: Array, default: []
   field :groups, type: Array
 
   # Options


### PR DESCRIPTION
AD syncinator and I'm sure others always assumes that the affiliations
and entitlements are at least blank arrays, the API doesn't seem to
enforce it one way or the other and you cannot send blank arrays through
it. So to correct the issue, default affilations and entitlements to a
blank array.